### PR TITLE
fix SyntaxError: f-string  and UserWarning: Glyph 35328

### DIFF
--- a/auditluma/orchestrator.py
+++ b/auditluma/orchestrator.py
@@ -682,6 +682,9 @@ class AgentOrchestrator:
             # 按漏洞数量排序
             sorted_vuln_types = sorted(vuln_types.items(), key=lambda x: x[1], reverse=True)
             
+            # 预先格式化漏洞类型列表
+            vuln_types_text = "\n".join([f"- {vuln_type}: {count}件" for vuln_type, count in sorted_vuln_types[:5]])
+            
             # 调用LLM API生成摘要
             system_prompt = """
 你是一个安全报告总结专家。请根据提供的扫描结果，生成一个简明扼要的执行摘要。
@@ -707,9 +710,7 @@ class AgentOrchestrator:
 - 信息: {severity_counts.get('info', 0)}
 
 最常见漏洞类型:
-{
-    '\\n'.join([f"- {vuln_type}: {count}件" for vuln_type, count in sorted_vuln_types[:5]])
-}
+{vuln_types_text}
 
 风险评分: {assessment.get('risk_score', 0)}/100
 

--- a/auditluma/visualizer/report_generator.py
+++ b/auditluma/visualizer/report_generator.py
@@ -10,13 +10,20 @@ from pathlib import Path
 import base64
 import io
 import html
+import re
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.font_manager import FontProperties
+
+# 设置matplotlib使用Agg后端（非交互式）
+matplotlib.use('Agg')
+
+# 配置matplotlib支持中文显示
+plt.rcParams['font.sans-serif'] = ['Microsoft YaHei', 'SimHei', 'SimSun']  # 按顺序寻找这些中文字体
+plt.rcParams['axes.unicode_minus'] = False  # 正确显示负号
 
 from loguru import logger
 from jinja2 import Environment, FileSystemLoader
-import matplotlib.pyplot as plt
-import matplotlib
-matplotlib.use('Agg')  # 使用非交互式后端
-import numpy as np
 
 from auditluma.config import Config
 from auditluma.models.code import VulnerabilityResult, SeverityLevel

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,5 @@ uvicorn>=0.23.2
 # black>=23.0.0
 # flake8>=6.0.0
 # mypy>=1.0.0
+# jinja2>=3.1.6
+# pyvis>=0.3.2


### PR DESCRIPTION
1. orchestrator.py
fix `SyntaxError: f-string expression part cannot include a backslash`

2. report_generator.py
fix 
```
UserWarning: Glyph 35328 (\N{CJK UNIFIED IDEOGRAPH-8A00}) missing from font(s) DejaVu Sans.
plt.savefig(buffer, format='png')
```

3. requirements.txt

      add jinja2 and pyvis